### PR TITLE
rename doesn't work across disks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,6 @@ verify_ssl = true
 [packages]
 flask-compress = "*"
 transformations = "*"
-pillow = ">=6.2.2"
+pillow = ">=9.0.0"
 flask = "*"
 gunicorn = "*"

--- a/server.py
+++ b/server.py
@@ -47,7 +47,7 @@ def _atomically_dump(f, target_path):
     with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
         try:
             shutil.copyfileobj(f, tmp_file)
-            os.rename(tmp_file.name, target_path)
+            shutil.move(tmp_file.name, target_path)
         except:
             os.remove(tmp_file.name)
             raise
@@ -63,7 +63,7 @@ def _write_cache_atomically(level_id, episode_id, filename, mode, data):
         try:
             with open(tmp_file.name, mode) as f:
                 f.write(data)
-            os.rename(tmp_file.name, target_path)
+            shutil.move(tmp_file.name, target_path)
         except:
             os.remove(tmp_file.name)
             raise


### PR DESCRIPTION
using docker volumes, every time the server.py tries to "rename" a file (from
/tmp to a docker volume) it generates an error: “Invalid cross-device link”.
Using shutils.move fixes it.  This allows me to keep the cache on a docker
volume that survives container restarts.

Bump Pillow version, security issue.  I did not regnerate the Pipfile.lock,
though, because I'm doing the work in a container and I don't exactly know
how to yet.  I just deleted it locally.